### PR TITLE
Check maximum number of characters before urlencode

### DIFF
--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -69,6 +69,9 @@ class GoogleTranslate
     protected static function requestTranslationGhost($source, $target, $text)
     {
 
+        if(strlen($text)>=5000)
+            throw new \Exception("Maximum number of characters exceeded: 5000");
+
         // Google translate URL
         $url = "https://translate.google.com/translate_a/single?client=at&dt=t&dt=ld&dt=qca&dt=rm&dt=bd&dj=1&hl=es-ES&ie=UTF-8&oe=UTF-8&inputm=2&otf=2&iid=1dd3b944-fa62-4b55-b330-74909a99969e";
 
@@ -77,9 +80,6 @@ class GoogleTranslate
             'tl' => urlencode($target),
             'q' => urlencode($text)
         );
-
-        if(strlen($fields['q'])>=5000)
-            throw new \Exception("Maximum number of characters exceeded: 5000");
         
         // URL-ify the data for the POST
         $fields_string = "";

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -173,6 +173,9 @@ class GoogleTranslate
     protected static function requestTranslation($source, $target, $text)
     {
 
+        if(strlen($text)>=5000)
+            throw new \Exception("Maximum number of characters exceeded: 5000");
+        
         // Google translate URL
         $url = "https://translate.google.com/translate_a/single?client=at&dt=t&dt=ld&dt=qca&dt=rm&dt=bd&dj=1&hl=es-ES&ie=UTF-8&oe=UTF-8&inputm=2&otf=2&iid=1dd3b944-fa62-4b55-b330-74909a99969e";
 
@@ -182,9 +185,6 @@ class GoogleTranslate
             'q' => urlencode($text)
         );
 
-        if(strlen($fields['q'])>=5000)
-            throw new \Exception("Maximum number of characters exceeded: 5000");
-        
         // URL-ify the data for the POST
         $fields_string = "";
         foreach ($fields as $key => $value) {


### PR DESCRIPTION
We need to check the maximum length of the character before encoding the text as the urlencode changes the number of character for special characters. 

For example `foo & bar` will change to `foo%20%26%20bar%20` and as a result the number of characters would increase. The API accepts the number of characters when encoded.